### PR TITLE
Fix for issue #4

### DIFF
--- a/bin/miR_table.R
+++ b/bin/miR_table.R
@@ -154,7 +154,7 @@ if(any(duplicated(values(miRs)$uniqueID))){
 
 knownOverlaps <- c()
 
-miROverlaps <- findOverlaps(miRs, ignoreSelf=TRUE)
+miROverlaps <- findOverlaps(miRs, drop.self=TRUE)
 
 overlappingMiRs <- miRs[unique(queryHits(miROverlaps))]
 


### PR DESCRIPTION
The parameter _ignoreSelf_ has been renamed  to _drop.self_ in IRanges v2.10.0 (see https://bioconductor.org/packages/release/bioc/news/IRanges/NEWS).